### PR TITLE
Only check object's own properties and not inherited ones

### DIFF
--- a/chai-angular.js
+++ b/chai-angular.js
@@ -101,10 +101,12 @@
         /* jshint forin: false */
         var a = [];
         for (var key in obj) {
-            if (ignoreResourceProperties && resourceProperties[key]) {
-                continue;
+            if (obj.hasOwnProperty(key)) {
+                if (ignoreResourceProperties && resourceProperties[key]) {
+                    continue;
+                }
+                a.push(key);
             }
-            a.push(key);
         }
         return a;
     }


### PR DESCRIPTION
Angular is adding a `toJSON` function to the `Resource` prototype which is causing comparisons to fail as the `expected` object does not contain this key (see https://github.com/angular/angular.js/blob/master/src/ngResource/resource.js#L504)
