### PR TITLE
Added TDD style asserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ The usual Chai syntactic variants are also available:
 
 ```javascript
 $scope.user.should.resourceEql({id: '9', name: 'Roger Zelazny'});
+
 expect($scope.user).to.deep.resource.equal({id: '9', name: 'Roger Zelazny'});
 expect($scope.user).to.resourceEql({id: '9', name: 'Roger Zelazny'});
+
+assert.resourceEqual($scope.user, {id: '9', name: 'Roger Zelazny'});
+assert.resourceNotEqual($scope.user, {id: '10', name: 'Philip K. Dick'});
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ expect($scope.user).to.deep.resource.equal({id: '9', name: 'Roger Zelazny'});
 expect($scope.user).to.resourceEql({id: '9', name: 'Roger Zelazny'});
 
 assert.resourceEqual($scope.user, {id: '9', name: 'Roger Zelazny'});
-assert.resourceNotEqual($scope.user, {id: '10', name: 'Philip K. Dick'});
+assert.notResourceEqual($scope.user, {id: '10', name: 'Philip K. Dick'});
 ```
 
 ## Installation

--- a/chai-angular.js
+++ b/chai-angular.js
@@ -17,7 +17,7 @@
         }
         chai.use(chaiModule);
     }
-})(function (chai, _) {
+})(function(chai, _) {
     'use strict';
 
     var resourceOwnProperties = {
@@ -25,12 +25,12 @@
         $resolved: true
     };
 
-    chai.Assertion.addChainableMethod('resource', null, function () {
+    chai.Assertion.addChainableMethod('resource', null, function() {
         _.flag(this, 'resource', true);
     });
 
     chai.Assertion.overwriteMethod('equal', function (_super) {
-        return function () {
+        return function() {
             if (_.flag(this, 'resource') && _.flag(this, 'deep')) {
                 return assertResourceEql.apply(this, arguments);
             }
@@ -47,7 +47,7 @@
         new chai.Assertion(val, msg).to.deep.resource.equal(exp);
     };
 
-    assert.resourceNotEqual = function (val, exp, msg) {
+    assert.notResourceEqual = function (val, exp, msg) {
         new chai.Assertion(val, msg).to.not.deep.resource.equal(exp);
     };
 
@@ -77,7 +77,7 @@
 
     function arrayResourceEql(obj, expected) {
         return Array.isArray(expected) && obj.length === expected.length &&
-            obj.every(function (item, i) {
+            obj.every(function(item, i) {
                 return resourceEql(item, expected[i]);
             });
     }
@@ -90,7 +90,7 @@
         var objKeys, expectedKeys;
 
         try {
-            objKeys = Object.keys(obj).filter(function (key) {
+            objKeys = Object.keys(obj).filter(function(key) {
                 return !resourceOwnProperties[key];
             });
             expectedKeys = Object.keys(expected);
@@ -98,8 +98,8 @@
             return false;
         }
 
-        return objKeys.length === expectedKeys.length && objKeys.every(function (key) {
-                return _.eql(obj[key], expected[key]);
-            });
+        return objKeys.length === expectedKeys.length && objKeys.every(function(key) {
+            return _.eql(obj[key], expected[key]);
+        });
     }
 });

--- a/chai-angular.js
+++ b/chai-angular.js
@@ -17,7 +17,7 @@
         }
         chai.use(chaiModule);
     }
-})(function(chai, _) {
+})(function (chai, _) {
     'use strict';
 
     var resourceOwnProperties = {
@@ -25,12 +25,12 @@
         $resolved: true
     };
 
-    chai.Assertion.addChainableMethod('resource', null, function() {
+    chai.Assertion.addChainableMethod('resource', null, function () {
         _.flag(this, 'resource', true);
     });
 
     chai.Assertion.overwriteMethod('equal', function (_super) {
-        return function() {
+        return function () {
             if (_.flag(this, 'resource') && _.flag(this, 'deep')) {
                 return assertResourceEql.apply(this, arguments);
             }
@@ -39,6 +39,17 @@
     });
 
     chai.Assertion.addMethod('resourceEql', assertResourceEql);
+
+    // TDD style asserts
+    var assert = chai.assert;
+
+    assert.resourceEqual = function (val, exp, msg) {
+        new chai.Assertion(val, msg).to.deep.resource.equal(exp);
+    };
+
+    assert.resourceNotEqual = function (val, exp, msg) {
+        new chai.Assertion(val, msg).to.not.deep.resource.equal(exp);
+    };
 
     function assertResourceEql(expected) {
         /* jshint validthis: true */
@@ -66,7 +77,7 @@
 
     function arrayResourceEql(obj, expected) {
         return Array.isArray(expected) && obj.length === expected.length &&
-            obj.every(function(item, i) {
+            obj.every(function (item, i) {
                 return resourceEql(item, expected[i]);
             });
     }
@@ -79,7 +90,7 @@
         var objKeys, expectedKeys;
 
         try {
-            objKeys = Object.keys(obj).filter(function(key) {
+            objKeys = Object.keys(obj).filter(function (key) {
                 return !resourceOwnProperties[key];
             });
             expectedKeys = Object.keys(expected);
@@ -87,8 +98,8 @@
             return false;
         }
 
-        return objKeys.length === expectedKeys.length && objKeys.every(function(key) {
-            return _.eql(obj[key], expected[key]);
-        });
+        return objKeys.length === expectedKeys.length && objKeys.every(function (key) {
+                return _.eql(obj[key], expected[key]);
+            });
     }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-angular",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Easier testing of Angular apps with Chai.",
   "main": "chai-angular.js",
   "scripts": {

--- a/test/chai-angular.js
+++ b/test/chai-angular.js
@@ -16,6 +16,7 @@ chai.use(require('..'));
 chai.should();
 
 var expect = chai.expect;
+var assert = chai.assert;
 
 require('angular/angular');
 require('angular-mocks');
@@ -30,6 +31,8 @@ function assertResourceEql(a, b) {
     }
     expect(a).to.resourceEql(b);
     expect(a).to.deep.resource.equal(b);
+
+    assert.resourceEqual(a, b);
 }
 
 function assertNotResourceEql(a, b) {
@@ -39,6 +42,8 @@ function assertNotResourceEql(a, b) {
     }
     expect(a).to.not.resourceEql(b);
     expect(a).to.not.deep.resource.equal(b);
+
+    assert.resourceNotEqual(a, b);
 }
 
 describe('chai-angular', function() {

--- a/test/chai-angular.js
+++ b/test/chai-angular.js
@@ -43,7 +43,7 @@ function assertNotResourceEql(a, b) {
     expect(a).to.not.resourceEql(b);
     expect(a).to.not.deep.resource.equal(b);
 
-    assert.resourceNotEqual(a, b);
+    assert.notResourceEqual(a, b);
 }
 
 describe('chai-angular', function() {


### PR DESCRIPTION
I'm using chai with TDD style, resourceEqual and resourceNotEqual asserts were missing.
Bumped version to 2.1.0.
